### PR TITLE
React-Components: Add keys to dynamic children

### DIFF
--- a/src/ui/react-components/registry-dialog.js
+++ b/src/ui/react-components/registry-dialog.js
@@ -62,7 +62,7 @@ define(function (require, exports) {
         </div>;
       } else {
         contents = this.state.registry.map(entry =>
-          <RegistryItem registryInfo={entry} />
+          <RegistryItem key={entry._id} registryInfo={entry} />
         );
       }
       return <div>

--- a/src/ui/react-components/registry-item.js
+++ b/src/ui/react-components/registry-item.js
@@ -80,8 +80,8 @@ define(function (require, exports, module) {
               </span>
             :
               <ul>
-                {this.getDependencies().map(obj =>
-                  <li><a className="defaultColor" href="" onClick={this.handleShowNpm.bind(this, obj.name)}>
+                {this.getDependencies().map((obj, i) =>
+                  <li key={i}><a className="defaultColor" href="" onClick={this.handleShowNpm.bind(this, obj.name)}>
                     {obj.name}@{obj.version}
                   </a></li>
                 )}


### PR DESCRIPTION
An unique `key`-prop should always be provided to dynamic children. This PR adds the missing `key` props to `<RegistryItem>`s (`entry._id`) and its dependencies (running index).

See http://facebook.github.io/react/docs/multiple-components.html#dynamic-children for more information.

