### PR TITLE
Use extension title in list if available

### DIFF
--- a/src/ui/react-components/registry-item.js
+++ b/src/ui/react-components/registry-item.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
         <div className="span10 text-left">
           <h1>
             <a className="defaultColor" onClick={this.handleShowNpm.bind(this, this.props.registryInfo.name)} href="#">
-              {registryInfo.name}
+              {registryInfo.title ? registryInfo.title + ' (' + registryInfo.name + ')' : registryInfo.name}
             </a>
           </h1>
           <h2>{registryInfo.description}</h2>


### PR DESCRIPTION
The [Brackets extension package format](https://github.com/adobe/brackets/wiki/Extension-package-format#packagejson-format) recommends a title field in the `package.json`.

This change makes the extension list use the title if available and fall back to the name if not:
![npm-registry](https://cloud.githubusercontent.com/assets/2564094/17275794/61cd9a24-5714-11e6-9852-008613b81673.png)
